### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "reactjs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ To run the project:
 1. Clone this repo
 2. Run `npm install`
 3. Run `npm start`
+
+[![Run on Repl.it](https://repl.it/badge/github/Bhupeshverma/robofriends)](https://repl.it/github/Bhupeshverma/robofriends)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@BHUPESHVERMA/robofriends).